### PR TITLE
Disable predictive text mac only

### DIFF
--- a/Riverbed.xcodeproj/project.pbxproj
+++ b/Riverbed.xcodeproj/project.pbxproj
@@ -672,7 +672,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1430;
-				LastUpgradeCheck = 1500;
+				LastUpgradeCheck = 1520;
 				TargetAttributes = {
 					03027DF12A13DF9D0063EE24 = {
 						CreatedOnToolsVersion = 14.3;
@@ -968,6 +968,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -1029,6 +1030,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";

--- a/Riverbed.xcodeproj/xcshareddata/xcschemes/Riverbed.xcscheme
+++ b/Riverbed.xcodeproj/xcshareddata/xcschemes/Riverbed.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1500"
+   LastUpgradeVersion = "1520"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Riverbed/UI/ElementCells/TextElementCell.swift
+++ b/Riverbed/UI/ElementCells/TextElementCell.swift
@@ -8,8 +8,20 @@ class TextElementCell: UITableViewCell, ElementCell, UITextFieldDelegate, UIText
 
     @IBOutlet private(set) var elementLabel: UILabel!
     @IBOutlet private(set) var layoutStack: UIStackView!
-    @IBOutlet private(set) var valueTextField: UITextField!
-    @IBOutlet private(set) var valueTextView: UITextView!
+    @IBOutlet private(set) var valueTextField: UITextField! {
+        didSet {
+            if (ProcessInfo.processInfo.isiOSAppOnMac) {
+                valueTextField.autocorrectionType = .no
+            }
+        }
+    }
+    @IBOutlet private(set) var valueTextView: UITextView! {
+        didSet {
+            if (ProcessInfo.processInfo.isiOSAppOnMac) {
+                valueTextField.autocorrectionType = .no
+            }
+        }
+    }
 
     func update(for element: Element, allElements: [Element], fieldValue: FieldValue?) {
         self.element = element

--- a/Riverbed/UI/ElementCells/TextElementCell.xib
+++ b/Riverbed/UI/ElementCells/TextElementCell.xib
@@ -41,7 +41,7 @@
                                 <rect key="frame" x="0.0" y="18.333333333333329" width="353" height="34"/>
                                 <color key="backgroundColor" systemColor="tertiarySystemFillColor"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences" autocorrectionType="no"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                 <connections>
                                     <outlet property="delegate" destination="laD-wy-ZvP" id="SSr-t6-92Y"/>
                                 </connections>
@@ -52,7 +52,7 @@
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences" autocorrectionType="no"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                 <connections>
                                     <outlet property="delegate" destination="laD-wy-ZvP" id="wPe-Vj-LAg"/>
                                 </connections>


### PR DESCRIPTION
Following on from #6, I found that disabling autocorrection on iOS disables a lot of the behavior you tend to rely on on mobile keyboards. This PR updates the code so autocorrection is default by default, and only turned off on Mac.