### PR TITLE
Fix field missed in turning off autocorrection

### DIFF
--- a/Riverbed/UI/ElementCells/TextElementCell.swift
+++ b/Riverbed/UI/ElementCells/TextElementCell.swift
@@ -18,7 +18,7 @@ class TextElementCell: UITableViewCell, ElementCell, UITextFieldDelegate, UIText
     @IBOutlet private(set) var valueTextView: UITextView! {
         didSet {
             if (ProcessInfo.processInfo.isiOSAppOnMac) {
-                valueTextField.autocorrectionType = .no
+                valueTextView.autocorrectionType = .no
             }
         }
     }


### PR DESCRIPTION
A field setting was modifying a property on an unrelated object. It's been fixed to set the property on the object that the setter is for, as intended.