### PR TITLE
Pass device timezone to server for card filtering

### DIFF
--- a/Riverbed/Data/API/RiverbedAPI.swift
+++ b/Riverbed/Data/API/RiverbedAPI.swift
@@ -45,8 +45,10 @@ struct RiverbedAPI {
         url(columnPath(columnId))
     }
 
-    static func columnCardsURL(for columnId: String) -> URL {
-        url(columnCardsPath(columnId))
+    static func columnCardsURL(for columnId: String, timezone: String) -> URL {
+        var components = URLComponents(url: url(columnCardsPath(columnId)), resolvingAgainstBaseURL: true)!
+        components.queryItems = [URLQueryItem(name: "timezone", value: timezone)]
+        return components.url!
     }
 
     static func elementsURL() -> URL {

--- a/Riverbed/Data/ColumnStore.swift
+++ b/Riverbed/Data/ColumnStore.swift
@@ -16,7 +16,8 @@ class ColumnStore: BaseStore {
     }
 
     func cards(for column: Column, completion: @escaping (Result<[Card], Error>) -> Void) {
-        let url = RiverbedAPI.columnCardsURL(for: column.id)
+        let timezone = TimeZone.current.identifier
+        let url = RiverbedAPI.columnCardsURL(for: column.id, timezone: timezone)
         var request = URLRequest(url: url)
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
 


### PR DESCRIPTION
## Summary

- Appends `?timezone=<IANA identifier>` to `GET /columns/:id/cards` requests using `TimeZone.current.identifier`
- Server uses this to evaluate time-zone-sensitive filter conditions (`IS_CURRENT_MONTH`, `IS_PAST`, `IS_FUTURE`, etc.) relative to the client's local time
- Implements the iOS client side of the spec in `docs/timezone-handling.md`

## Test plan

- [ ] Build succeeds
- [ ] On a device/simulator set to a non-UTC timezone, columns with date-based filters (current month, past, future) reflect the local date rather than UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)