### PR TITLE
Fix missing buttons in preview

### DIFF
--- a/Riverbed.xcodeproj/project.pbxproj
+++ b/Riverbed.xcodeproj/project.pbxproj
@@ -1250,7 +1250,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = Riverbed/Riverbed.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Riverbed/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
@@ -1265,7 +1265,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.codingitwrong.riverbed.uikit.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1282,7 +1282,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = Riverbed/Riverbed.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Riverbed/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
@@ -1297,7 +1297,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.codingitwrong.riverbed.uikit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1382,7 +1382,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = RiverbedShare/RiverbedShare.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = RiverbedShare/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Riverbed;
@@ -1393,7 +1393,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.codingitwrong.riverbed.uikit.dev.RiverbedShare;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1408,7 +1408,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = RiverbedShare/RiverbedShare.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = RiverbedShare/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Riverbed;
@@ -1419,7 +1419,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.codingitwrong.riverbed.uikit.RiverbedShare;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Riverbed/UI/Board/BoardViewController.swift
+++ b/Riverbed/UI/Board/BoardViewController.swift
@@ -687,6 +687,9 @@ class BoardViewController: UIViewController,
 
         switch segue.identifier {
         case "showCardDetail":
+            // only when navigating directly via tapping
+            // for opening preview see CardSummaryCollectionCell contextMenuInteraction(_:configurationForMenuAtLocation:)
+            // for taking preview to full navigation see CardSummaryCollectionCell contextMenuInteraction(_:willPerformPreviewActionForMenuWith:animator)
             guard let cardVC = segue.destination as? CardViewController else {
                 preconditionFailure("Expected CardViewController")
             }
@@ -695,6 +698,7 @@ class BoardViewController: UIViewController,
             }
 
             prepare(cardViewController: cardVC, with: card)
+            cardVC.applyLiquidGlassEffects()
 
         case "editBoard":
             guard let editBoardNavController = segue.destination as? UINavigationController,

--- a/Riverbed/UI/Board/CardSummaryCollectionCell.swift
+++ b/Riverbed/UI/Board/CardSummaryCollectionCell.swift
@@ -237,6 +237,9 @@ class CardSummaryCollectionCell: UICollectionViewCell,
         guard let cardVC = animator.previewViewController as? CardViewController else {
             preconditionFailure("Expected a CardViewController")
         }
+        
+        cardVC.applyLiquidGlassEffects()
+        
         animator.addCompletion {
             self.delegate?.didSelect(preview: cardVC)
         }

--- a/Riverbed/UI/Card/CardViewController.swift
+++ b/Riverbed/UI/Card/CardViewController.swift
@@ -40,6 +40,8 @@ class CardViewController: UITableViewController,
         }
     }
 
+    private var shouldApplyLiquidGlassEffects = false
+    
     weak var delegate: CardViewControllerDelegate?
     private var isCardDeleted = false
 
@@ -141,6 +143,9 @@ class CardViewController: UITableViewController,
             deleteButton.configuration = .prominentGlass()
             deleteButton.configuration?.image = UIImage(systemName: "trash")
         }
+
+        shouldApplyLiquidGlassEffects = true
+        tableView.reloadData()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -335,6 +340,18 @@ class CardViewController: UITableViewController,
         cell.delegate = self
         let fieldValue = singularizeOptionality(fieldValues[element.id])
         cell.update(for: element, allElements: elements, fieldValue: fieldValue)
+        
+        // TODO: if button cell and not in preview mode, call to set liquid glass
+        if shouldApplyLiquidGlassEffects {
+            // TODO: remove duplication in cell type checks
+            if let buttonCell = cell as? ButtonElementCell {
+                buttonCell.applyLiquidGlassEffects()
+            }
+            if let buttonMenuCell = cell as? ButtonMenuElementCell {
+                buttonMenuCell.applyLiquidGlassEffects()
+            }
+        }
+        
         return cell
     }
 

--- a/Riverbed/UI/Card/CardViewController.swift
+++ b/Riverbed/UI/Card/CardViewController.swift
@@ -21,15 +21,10 @@ class CardViewController: UITableViewController,
         }
     }
     
-    @IBOutlet private var beginEditingButton: UIButton! {
-        didSet {
-            if #available(iOS 26, *) {
-                beginEditingButton.configuration = .glass()
-                beginEditingButton.configuration?.image = UIImage(systemName: "wrench")
-            }
-        }
-    }
+    @IBOutlet private var beginEditingButton: UIButton!
 
+    @IBOutlet private var deleteButton: UIButton!
+    
     @IBOutlet private var endEditingButton: UIButton! {
         didSet {
             if #available(iOS 26, *) {
@@ -39,15 +34,6 @@ class CardViewController: UITableViewController,
         }
     }
 
-    @IBOutlet private var deleteButton: UIButton! {
-        didSet {
-            if #available(iOS 26, *) {
-                deleteButton.configuration = .prominentGlass()
-                deleteButton.configuration?.image = UIImage(systemName: "trash")
-            }
-        }
-    }
-    
     @IBOutlet private var instructionLabel: UILabel! {
         didSet {
             instructionLabel.text = nil
@@ -145,6 +131,16 @@ class CardViewController: UITableViewController,
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         deleteButton.tintColor = .systemRed
+    }
+    
+    func applyLiquidGlassEffects() {
+        if #available(iOS 26, *) {
+            beginEditingButton.configuration = .glass()
+            beginEditingButton.configuration?.image = UIImage(systemName: "wrench")
+
+            deleteButton.configuration = .prominentGlass()
+            deleteButton.configuration?.image = UIImage(systemName: "trash")
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/Riverbed/UI/ElementCells/ButtonElementCell.swift
+++ b/Riverbed/UI/ElementCells/ButtonElementCell.swift
@@ -7,17 +7,17 @@ class ButtonElementCell: UITableViewCell, ElementCell {
     var buttonElement: Element!
     var allElements: [Element]!
 
-    @IBOutlet private(set) var button: UIButton! {
-        didSet {
-            if #available(iOS 26, *) {
-                button.configuration = .prominentGlass()
-            }
-        }
-    }
+    @IBOutlet private(set) var button: UIButton!
     
     @IBOutlet private(set) var leadingConstraint: NSLayoutConstraint!
     @IBOutlet private(set) var trailingConstraint: NSLayoutConstraint!
 
+    func applyLiquidGlassEffects() {
+        if #available(iOS 26, *) {
+            button.configuration = .prominentGlass()
+        }
+    }
+    
     override func willMove(toSuperview newSuperview: UIView?) {
         super.willMove(toSuperview: newSuperview)
         

--- a/Riverbed/UI/ElementCells/ButtonMenuElementCell.swift
+++ b/Riverbed/UI/ElementCells/ButtonMenuElementCell.swift
@@ -6,16 +6,16 @@ class ButtonMenuElementCell: UITableViewCell, ElementCell {
 
     var allElements: [Element]!
 
-    @IBOutlet private(set) var menuButton: UIButton! {
-        didSet {
-            if #available(iOS 26, *) {
-                menuButton.configuration = .prominentGlass()
-            }
-        }
-    }
+    @IBOutlet private(set) var menuButton: UIButton!
 
     @IBOutlet private(set) var leadingConstraint: NSLayoutConstraint!
     @IBOutlet private(set) var trailingConstraint: NSLayoutConstraint!
+
+    func applyLiquidGlassEffects() {
+        if #available(iOS 26, *) {
+            menuButton.configuration = .prominentGlass()
+        }
+    }
 
     override func willMove(toSuperview newSuperview: UIView?) {
         super.willMove(toSuperview: newSuperview)


### PR DESCRIPTION
In iOS 26, when you long-press a card in the list, the card preview that pops up has title buttons and button elements missing. This is because previews cannot show buttons with liquid glass effects. This PR fixes this by deferring the applying of liquid glass effects to buttons so it isn't done as soon as the VC is instantiated. Instead, it is done once:

1. The VC is presented in the normal way, or
2. The VC is committed to the stack after having been shown as a preview