### PR TITLE
Reduce cases of Mac shadow flicker

### DIFF
--- a/Riverbed.xcodeproj/project.pbxproj
+++ b/Riverbed.xcodeproj/project.pbxproj
@@ -1250,7 +1250,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = Riverbed/Riverbed.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Riverbed/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
@@ -1282,7 +1282,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = Riverbed/Riverbed.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Riverbed/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
@@ -1382,7 +1382,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = RiverbedShare/RiverbedShare.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = RiverbedShare/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Riverbed;
@@ -1408,7 +1408,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = RiverbedShare/RiverbedShare.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = RiverbedShare/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Riverbed;

--- a/Riverbed/UI/Card/CardViewController.swift
+++ b/Riverbed/UI/Card/CardViewController.swift
@@ -431,7 +431,7 @@ class CardViewController: UITableViewController,
         delegate?.didUpdateElements(forCard: card)
     }
 
-    func update(value: FieldValue?, for element: Element) {
+    func update(value: FieldValue?, for element: Element, canChangeHeight: Bool = false) {
         // avoid creating a new instance if not needed, to preserve value equality
         if fieldValues[element.id] != value {
             if case let .string(stringValue) = value,

--- a/Riverbed/UI/Card/CardViewController.swift
+++ b/Riverbed/UI/Card/CardViewController.swift
@@ -442,7 +442,10 @@ class CardViewController: UITableViewController,
             }
         }
 
-        recomputeTableCellSizes()
+        // recomputeTableCellSizes causes shadow flicker on macOS, so avoid it unless necessary
+        if (canChangeHeight) {
+            recomputeTableCellSizes()
+        }
     }
 
     func update(values: [String: FieldValue?], dismiss: Bool) {

--- a/Riverbed/UI/Conditions/EditConditionViewController.swift
+++ b/Riverbed/UI/Conditions/EditConditionViewController.swift
@@ -154,7 +154,7 @@ class EditConditionViewController: UITableViewController,
 
     var fieldValues = [String: FieldValue?]()
 
-    func update(value: FieldValue?, for element: Element) {
+    func update(value: FieldValue?, for element: Element, canChangeHeight: Bool) {
         if condition.options == nil {
             condition.options = Condition.Options()
         }

--- a/Riverbed/UI/Element/EditActionViewController.swift
+++ b/Riverbed/UI/Element/EditActionViewController.swift
@@ -156,7 +156,7 @@ class EditActionViewController: UITableViewController,
 
     var fieldValues: [String: FieldValue?] = [:] // unused
 
-    func update(value: FieldValue?, for element: Element) {
+    func update(value: FieldValue?, for element: Element, canChangeHeight: Bool) {
         action.specificValue = value
     }
 

--- a/Riverbed/UI/Element/EditElementViewController.swift
+++ b/Riverbed/UI/Element/EditElementViewController.swift
@@ -458,7 +458,7 @@ class EditElementViewController: UITableViewController,
 
     var fieldValues = [String: FieldValue?]()
 
-    func update(value: FieldValue?, for element: Element) {
+    func update(value: FieldValue?, for element: Element, canChangeHeight: Bool) {
         ensureOptionsPresent()
         attributes.options?.initialSpecificValue = value
     }

--- a/Riverbed/UI/ElementCells/ElementCell.swift
+++ b/Riverbed/UI/ElementCells/ElementCell.swift
@@ -3,8 +3,15 @@ import UIKit
 protocol ElementCellDelegate: AnyObject {
     var fieldValues: [String: FieldValue?] { get }
 
-    func update(value: FieldValue?, for element: Element)
+    func update(value: FieldValue?, for element: Element, canChangeHeight: Bool)
     func update(values: [String: FieldValue?], dismiss: Bool)
+}
+
+extension ElementCellDelegate {
+    // effectively make canChangeHeight an optional argument with default value false
+    func update(value: FieldValue?, for element: Element) {
+        update(value: value, for: element, canChangeHeight: false)
+    }
 }
 
 protocol ElementCell: UITableViewCell {

--- a/Riverbed/UI/ElementCells/TextElementCell.swift
+++ b/Riverbed/UI/ElementCells/TextElementCell.swift
@@ -128,7 +128,9 @@ class TextElementCell: UITableViewCell, ElementCell, UITextFieldDelegate, UIText
     func passUpdatedValueToDelegate(_ value: String?) {
         guard let element = element,
               let value = value else { return }
-        delegate?.update(value: .string(value), for: element)
+        
+        let canChangeHeight = element.attributes.options?.multiline ?? false
+        delegate?.update(value: .string(value), for: element, canChangeHeight: canChangeHeight)
     }
 
 }


### PR DESCRIPTION
Previously, within a card, when typing in any text field the shadows on buttons and dropdowns would flicker. This is triggered by table updating, which we do upon every value change because text changes to multiline text fields may cause its cell height to change.

However, the only value change that can cause cell height changes is a value change in a multiline text field. Any other value change we don't need to recompute table heights.

This PR updates the `update(values:…)` delegate method to pass `canChangeHeight: Bool`, and changes the table update logic so that it only runs when `canChangeHeight == true`. This removes flicker for all value changes *except* multiline text fields.

It would be good if I can later remove the flicker for multiline text fields too, but this is a step in the right direction, as well as removing some unnecessary work.