### PR TITLE
Blank card issue

### DIFF
--- a/Riverbed.xcodeproj/project.pbxproj
+++ b/Riverbed.xcodeproj/project.pbxproj
@@ -1250,7 +1250,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = Riverbed/Riverbed.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 43;
+				CURRENT_PROJECT_VERSION = 44;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Riverbed/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
@@ -1282,7 +1282,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = Riverbed/Riverbed.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 43;
+				CURRENT_PROJECT_VERSION = 44;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Riverbed/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
@@ -1382,7 +1382,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = RiverbedShare/RiverbedShare.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 43;
+				CURRENT_PROJECT_VERSION = 44;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = RiverbedShare/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Riverbed;
@@ -1408,7 +1408,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = RiverbedShare/RiverbedShare.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 43;
+				CURRENT_PROJECT_VERSION = 44;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = RiverbedShare/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Riverbed;

--- a/Riverbed/UI/Board/BoardViewController.swift
+++ b/Riverbed/UI/Board/BoardViewController.swift
@@ -38,6 +38,7 @@ class BoardViewController: UIViewController,
     
     var isLoadingBoard = false
     var isFirstLoadingBoard = true
+    var wasLastCardSelectionByCreation = false
 
     var boardStore: BoardStore!
     var cardStore: CardStore!
@@ -358,6 +359,7 @@ class BoardViewController: UIViewController,
             
             switch result {
             case let .success(card):
+                wasLastCardSelectionByCreation = true
                 self.didSelect(card: card)
             case let .failure(error):
                 print("Error creating card: \(String(describing: error))")
@@ -746,6 +748,10 @@ class BoardViewController: UIViewController,
         cardViewController.elementStore = elementStore
         cardViewController.cardStore = cardStore // TODO: setter order dependency unfortunate
         cardViewController.card = card
+        cardViewController.isNewCard = wasLastCardSelectionByCreation
+        
+        // reset
+        wasLastCardSelectionByCreation = false
     }
 
 }

--- a/Riverbed/UI/Board/BoardViewController.swift
+++ b/Riverbed/UI/Board/BoardViewController.swift
@@ -359,7 +359,6 @@ class BoardViewController: UIViewController,
             switch result {
             case let .success(card):
                 self.didSelect(card: card)
-                self.loadBoardData()
             case let .failure(error):
                 print("Error creating card: \(String(describing: error))")
                 self.showAlert(withErrorMessage: "An error occurred while adding a card.")

--- a/Riverbed/UI/Card/CardViewController.swift
+++ b/Riverbed/UI/Card/CardViewController.swift
@@ -152,7 +152,7 @@ class CardViewController: UITableViewController,
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
-        let isCardChanged = fieldValues != originalFieldValues
+        let isCardChanged = isNewCard || fieldValues != originalFieldValues
 
         if isCardDeleted {
             delegate?.didDelete(card: card)

--- a/Riverbed/UI/Card/CardViewController.swift
+++ b/Riverbed/UI/Card/CardViewController.swift
@@ -62,6 +62,7 @@ class CardViewController: UITableViewController,
     }
     var originalFieldValues = [String: FieldValue?]()
     var fieldValues = [String: FieldValue?]()
+    var isNewCard: Bool!
 
     func loadFieldValues() {
         // get latest values from server in case it's changed from the list view


### PR DESCRIPTION
#31 fixed an issue where, if you created a card then closed it without editing it, it wouldn't show in the board. You needed to explicitly reload.

But #31 caused a smaller UX problem: when you create a new card, then close it, you see a blank card shown until the new value of the card is loaded. Not ideal.

This PR fixes it differently:

- We keep the logic where, after opening a card, reloading of the board only happens after you dismiss the card. This minimizes reloads and ensures that you don't get the "blank card" intermediate state
- When does closing a card trigger a reload? Still when the values have been changed (pre-existing logic). But now we also pass a flag to the card VC saying if it was opened via creating a new card. If so, we reload on close, even if the values didn't change.